### PR TITLE
yusuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,10 @@ kubectl -n ambassador wait --for condition=available --timeout=90s deploy -lprod
 
 By using issuer.yml:
 ```
-kapp issuer.yml
+~kapp issuer.yml
+
+host.getambassador.io/example-host configured
+
 ```
 ```
 apiVersion: getambassador.io/v2

--- a/README.md
+++ b/README.md
@@ -462,6 +462,16 @@ spec:
 ### Enabling Proxy Protocol
 There are lot of configuration options available to you when running Ambassador Edge Stack but we will focus on automatic certificate management in the Ambassador Edge Stack in this part. After deploying the Service above  and manually enabling the proxy protocol you have to need to deploy the following Ambassador Module to manage Ambassador Edge Stack to utilize the proxy protocol and then restart Ambassador Edge Stack for the configuration to take effect.
 
+Also you can create load balancer by using configuration like below
+[For more Details](https://github.com/digitalocean/digitalocean-cloud-controller-manager/tree/master/docs/controllers/services/examples)
+
+```
+~ doctl compute load-balancer list
+
+```
+By using above command you can see that all loadbalancer list for your cluster. Also you can create your own load balancer with proxy by using DO web dashboard. 
+[For more information](https://www.digitalocean.com/community/questions/how-to-set-up-nginx-ingress-for-load-balancers-with-proxy-protocol-support)
+
 [For More details about how to use proxy for Ambassador](https://www.getambassador.io/docs/edge-stack/1.13/topics/running/ambassador-with-aws/). You can create a proxy in Ambassador by using below code.Ambassador Edge Stack will now expect traffic from the load balancer to be wrapped with the proxy protocol so it can read the client IP address.
 
 ```

--- a/README.md
+++ b/README.md
@@ -453,8 +453,8 @@ quote              ClusterIP      10.245.172.174   <none>            80/TCP     
 ```
 
 ### :performing_arts: Creating A Proxy
+Because of using L4 LB , we have to enable proxy protocol through an annotation.After running this command, the public and private load balancers that expose your LB with the PROXY protocol feature enabled.
 
-Having also enabled proxy protocol through an annotation, because I am using an L4 LB.
 ```
 ~ kgsvcn ambassador ambassador -o yaml | grep proxy        
     service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"  

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Ambassador Edge Stack is a specialized [control plane for Envoy Proxy](https://b
 4.  The new configuration is passed to Envoy via the gRPC-based Aggregated Discovery Service (ADS) API.
 5.  Traffic flows through the reconfigured Envoy, without dropping any connections.
 
-More Details and extended explanation please visit: [Yhe Ambassador Edge Stack Architecture](https://www.getambassador.io/docs/edge-stack/2.0/topics/concepts/architecture/) 
+More Details and extended explanation please visit: [The Ambassador Edge Stack Architecture](https://www.getambassador.io/docs/edge-stack/2.0/topics/concepts/architecture/) 
 
 
  #### :arrow_down_small: Install Ambassador

--- a/README.md
+++ b/README.md
@@ -418,8 +418,7 @@ As the last configuration step, create the mapping for Ambassador.
 #### Configure Mapping for each Hosts
 
 Ambassador Edge Stack is designed around a [declarative, self-service management model](https://www.getambassador.io/docs/edge-stack/latest/topics/concepts/gitops-continuous-delivery) It means that you can manage the edge with Ambassador Edge Stack is the `Mapping` resource.
-> More info : :pushpin:
-https://www.getambassador.io/docs/edge-stack/1.13/topics/using/intro-mappings/
+> More info : https://www.getambassador.io/docs/edge-stack/1.13/topics/using/intro-mappings/
 
 This Mapping is managing Edge Stack to route all traffic inbound to the /backend/ path to the quote & also /echo/ to the echo service.
 **Details**
@@ -469,10 +468,11 @@ Also you can create load balancer by using configuration like below
 ~ doctl compute load-balancer list
 
 ```
-By using above command you can see that all loadbalancer list for your cluster. Also you can create your own load balancer with proxy by using DO web dashboard. 
+By using the above command you can see that all loadbalancer lists for your cluster. Also, you can create your load balancer with proxy by using DO web dashboard automatically. When you check advanced settings of kub cluster, The most commonly used settings are selected by default, you can change them at any time by clicking "Edit Advanced Settings". When you decide to add Proxy for your cluster, you can proxy protocol setting.
+
 [For more information](https://www.digitalocean.com/community/questions/how-to-set-up-nginx-ingress-for-load-balancers-with-proxy-protocol-support)
 
-[For More details about how to use proxy for Ambassador](https://www.getambassador.io/docs/edge-stack/1.13/topics/running/ambassador-with-aws/). You can create a proxy in Ambassador by using below code.Ambassador Edge Stack will now expect traffic from the load balancer to be wrapped with the proxy protocol so it can read the client IP address.
+[For More details about how to use proxy for Ambassador](https://www.getambassador.io/docs/edge-stack/1.13/topics/running/ambassador-with-aws/). You can create a proxy in Ambassador by using below code. Ambassador Edge Stack will now expect traffic from the load balancer to be wrapped with the proxy protocol so it can read the client IP address.
 
 ```
 apiVersion: getambassador.io/v2
@@ -572,15 +572,12 @@ quote              ClusterIP      10.245.229.63    <none>            80/TCP     
  
  ```
 
+Now let us quote the connectivity. In the simple sample below, when invoked without any option, curl displays the specified resource to the standard output of hosted services. You can see that quote.mandrakee.xyz doesn't have any echo
+end point. Because of that, the result is empty. The same situation happens for echo.mandrakee.xyz when calling quote end point. 
 
+*Checking quote service with quote endpoint. Being sure it returns 200 OK.*
 
-
-
-Now let us quote the connectivity.
-
-Checking quote service with quote endpoint. Being sure it returns 200 OK.
 ```
-
 ~ curl -Li http://quote.mandrakee.xyz/echo/
 HTTP/1.1 404 Not Found
 date: Sun, 25 Jul 2021 22:13:04 GMT
@@ -617,8 +614,7 @@ Content-Length: 0
 
 
 ```
-Checking echo service with backend endpoint. Being sure it returns 200 OK.
-
+*Checking echo service with backend endpoint. Being sure it returns 200 OK.*
 ```
 ~ curl -Li http://echo.mandrakee.xyz/quote/ 
 HTTP/1.1 404 Not Found

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ More Details and extended explanation please visit: [The Ambassador Edge Stack A
 The set of configuration steps are as follows
 - Install AES.
 - Configure 2 hosts (domain1, domain2) on the cluster. For this example, we're using quote.mandake.xyz, and echo.mandrake.xyz as 2 differents hosts on the same cluster.
-- Enable different paths for the domains. For quote.mandrake.xyz, we create a backend service called quote. For echo.mandrake.xyz, we create a backend service called quote.
+- Enable different paths for the domains. For quote.mandrake.xyz, we create a backend service called quote. For echo.mandrake.xyz, we create a echo service called echo.
 - Domains are configured with TLS, and have different URL paths.
 - Verify the installation.
 
@@ -325,9 +325,7 @@ By using Deployment.Yml:
   deployment.apps/quote configured
   deployment.apps/echo configured
 
-```
-
-```
+#Deployment.yml for quote and echo images
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -352,7 +350,7 @@ spec:
         ports:
         - name: http
           containerPort: 8080
-          
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -386,6 +384,8 @@ After Deployment, we can use below yml configuration for services up!
 ```
 
 ```
+#service.yml for quote and echo deployment.
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -465,7 +465,6 @@ There are lot of configuration options available to you when running Ambassador 
 [For More details about how to use proxy for Ambassador](https://www.getambassador.io/docs/edge-stack/1.13/topics/running/ambassador-with-aws/). You can create a proxy in Ambassador by using below code.Ambassador Edge Stack will now expect traffic from the load balancer to be wrapped with the proxy protocol so it can read the client IP address.
 
 ```
- 
 apiVersion: getambassador.io/v2
 kind: Module
 metadata:
@@ -482,9 +481,9 @@ spec:
 
 ```
 ~ kg host -A                                                              
-NAMESPACE    NAME                                HOSTNAME                            STATE   PHASE COMPLETED   PHASE PENDING   AGE  
-default      quote-host                        quote.mandrakee.xyz                  Ready                                     18h  
-default      echo-host                       echo.mandrakee.xyz                  Ready                                     9m19s
+NAMESPACE    NAME                              HOSTNAME                           STATE   PHASE COMPLETED   PHASE PENDING   AGE  
+default      quote-host                        quote.mandrakee.xyz                Ready                                     18h  
+default      echo-host                         echo.mandrakee.xyz                 Ready                                     9m19s
 ```
 > Checking  2 independent mappings. Please be sure mapping is correct such as source host etc.
 
@@ -495,8 +494,8 @@ ambassador   ambassador-devportal                                 /documentation
 ambassador   ambassador-devportal-api                             /openapi/                                   127.0.0.1:8500             
 ambassador   ambassador-devportal-assets                          /documentation/(assets|styles)/(.*)(.css)   127.0.0.1:8500             
 ambassador   ambassador-devportal-demo                            /docs/                                      127.0.0.1:8500             
-ambassador   quote-backend                 echo.mandrakee.xyz     /backend/                                   quote                      
-default      echo-backend                  quote.mandrakee.xyz     /echo/                                      echo-service      
+ambassador   quote-backend                 quote.mandrakee.xyz    /quote/                                     quote-service                      
+default      echo-backend                  echo.mandrakee.xyz     /echo/                                      echo-service      
 
 ~ kg mapping -n ambassador echo-backend -o yaml  
 ...  
@@ -505,7 +504,7 @@ kind: Mapping
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"getambassador.io/v2","kind":"Mapping","metadata":{"annotations":{},"name":"echo-backend","namespace":"ambassador"},"spec":{"host":"echo.mandrakee.xyz","prefix":"/echo/","service":"echo"}}
+      {"apiVersion":"getambassador.io/v2","kind":"Mapping","metadata":{"annotations":{},"name":"echo-backend","namespace":"ambassador"},"spec":{"host":"echo.mandrakee.xyz","prefix":"/echo/","service":"echo-service"}}
   creationTimestamp: "2021-07-30T16:11:57Z"
   generation: 1
   name: echo-backend
@@ -525,34 +524,19 @@ kind: Mapping
 metadata:
   annotations:
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"getambassador.io/v2","kind":"Mapping","metadata":{"annotations":{},"name":"echo-backend","namespace":"ambassador"},"spec":{"host":"echo.mandrakee.xyz","prefix":"/echo/","service":"echo"}}
+      {"apiVersion":"getambassador.io/v2","kind":"Mapping","metadata":{"annotations":{},"name":"quote-backend","namespace":"ambassador"},"spec":{"host":"quote.mandrakee.xyz","prefix":"/quote/","service":"quote-service"}}
   creationTimestamp: "2021-07-30T16:11:57Z"
   generation: 1
-  name: echo-backend
+  name: quote-backend
   namespace: ambassador
   resourceVersion: "1239310"
   uid: 3fc67511-6e04-4d56-bde2-5de07fcc9748
 spec:
-  host: echo.mandrakee.xyz
-  prefix: /echo/
-  service: echo
-root@ubuntu-s-1vcpu-2gb-fra1-01:~/setup/AES# kg mapping -n ambassador quote-backend -o yaml
-apiVersion: getambassador.io/v2
-kind: Mapping
-metadata:
-  annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"getambassador.io/v2","kind":"Mapping","metadata":{"annotations":{},"name":"quote-backend","namespace":"ambassador"},"spec":{"host":"quote.mandrakee.xyz","prefix":"/backend/","service":"quote"}}
-  creationTimestamp: "2021-07-30T16:11:56Z"
-  generation: 1
-  name: quote-backend
-  namespace: ambassador
-  resourceVersion: "1239306"
-  uid: 6f7e1766-5554-435a-8335-bc7371b89ada
-spec:
   host: quote.mandrakee.xyz
-  prefix: /backend/
+  prefix: /quote/
   service: quote
+
+
  
  ```
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ kubectl -n ambassador wait --for condition=available --timeout=90s deploy -lprod
 ```
 #### :memo: Create Issuer
    Enabling 2 domains (eg. echo & test ) to be hosted on the cluster, using ACME provider letsencrypt. Issuer.yml will help us. When you look at belowsample,  you will see that only one host, please create example2-host for echo service helps to host multiple TLS-enabled hosts on the same cluster.
+
+By using issuer.yml:
+```
+kapp issuer.yml
+```
 ```
 apiVersion: getambassador.io/v2
 kind: Host
@@ -239,17 +244,40 @@ metadata:
 spec:
   acmeProvider:
     authority: 'https://acme-v02.api.letsencrypt.org/directory'
-    email: bikram.gupta-40gmail.com
+    email: test@gmail.com
   ambassadorId:
     - default
-  hostname: test.kubenuggets.dev
+  hostname: test.mandrakee.xyz
   requestPolicy:
     insecure:
       action: Redirect
       additionalPort: 8080
   selector:
     matchLabels:
-      hostname: test.kubenuggets.dev
+      hostname: test.mandrakee.xyz
+  tlsSecret:
+    name: tls-cert
+
+---
+apiVersion: getambassador.io/v2
+kind: Host
+metadata:
+  name: example2-host
+  namespace: default
+spec:
+  acmeProvider:
+    authority: 'https://acme-v02.api.letsencrypt.org/directory'
+    email: test@gmail.com
+  ambassadorId:
+    - default
+  hostname: echo.mandrakee.xyz
+  requestPolicy:
+    insecure:
+      action: Redirect
+      additionalPort: 8080
+  selector:
+    matchLabels:
+      hostname: echo.mandrakee.xyz
   tlsSecret:
     name: tls-cert
 ```

--- a/README.md
+++ b/README.md
@@ -499,13 +499,15 @@ default      echo-host                         echo.mandrakee.xyz               
 
  ```
  ~ kg mapping -A  
-NAMESPACE    NAME                          SOURCE HOST            SOURCE PREFIX                               DEST SERVICE     STATE   REASON  
-ambassador   ambassador-devportal                                 /documentation/                             127.0.0.1:8500             
-ambassador   ambassador-devportal-api                             /openapi/                                   127.0.0.1:8500             
-ambassador   ambassador-devportal-assets                          /documentation/(assets|styles)/(.*)(.css)   127.0.0.1:8500             
-ambassador   ambassador-devportal-demo                            /docs/                                      127.0.0.1:8500             
-ambassador   quote-backend                 quote.mandrakee.xyz    /quote/                                     quote-service                      
-default      echo-backend                  echo.mandrakee.xyz     /echo/                                      echo-service      
+ 
+NAMESPACE    NAME                          SOURCE HOST           SOURCE PREFIX                               DEST SERVICE     STATE   REASON
+ambassador   ambassador-devportal                                /documentation/                             127.0.0.1:8500
+ambassador   ambassador-devportal-api                            /openapi/                                   127.0.0.1:8500
+ambassador   ambassador-devportal-assets                         /documentation/(assets|styles)/(.*)(.css)   127.0.0.1:8500
+ambassador   ambassador-devportal-demo                           /docs/                                      127.0.0.1:8500
+ambassador   echo-backend                  echo.mandrakee.xyz    /echo/                                      echo
+ambassador   quote-backend                 quote.mandrakee.xyz   /quote/                                     quote
+     
 
 ~ kg mapping -n ambassador echo-backend -o yaml  
 ...  
@@ -547,8 +549,32 @@ spec:
   service: quote
 
 
+
+~doctl compute domain records list mandrakee.xyz 
+
+ID           Type    Name     Data                    Priority    Port    TTL     Weight
+162442979    SOA     @        1800                    0           0       1800    0
+162442981    NS      @        ns1.digitalocean.com    0           0       1800    0
+162442983    NS      @        ns2.digitalocean.com    0           0       1800    0
+162442986    NS      @        ns3.digitalocean.com    0           0       1800    0
+162892121    A       echo     143.244.208.191         0           0       3600    0
+164017635    A       quote    143.244.208.191         0           0       3600    0
+
+~kgsvcn ambassador
+
+NAME               TYPE           CLUSTER-IP       EXTERNAL-IP       PORT(S)                      AGE
+ambassador         LoadBalancer   10.245.92.121    143.244.208.191   80:31153/TCP,443:30706/TCP   6d6h
+ambassador-admin   ClusterIP      10.245.23.172    <none>            8877/TCP,8005/TCP            6d6h
+ambassador-redis   ClusterIP      10.245.133.196   <none>            6379/TCP                     6d6h
+echo               ClusterIP      10.245.27.179    <none>            80/TCP                       13s
+quote              ClusterIP      10.245.229.63    <none>            80/TCP                       13s
+
  
  ```
+
+
+
+
 
 Now let us quote the connectivity.
 

--- a/README.md
+++ b/README.md
@@ -538,18 +538,60 @@ default      echo-backend                  test.mandrakee.xyz     /echo/        
 
 ~ kg mapping -n ambassador echo-backend -o yaml  
 ...  
-spec:  
-  host: test.mandrakee.xyz  
-  prefix: /echo/  
-  service: echo-service  
-~   
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"getambassador.io/v2","kind":"Mapping","metadata":{"annotations":{},"name":"echo-backend","namespace":"ambassador"},"spec":{"host":"echo.mandrakee.xyz","prefix":"/echo/","service":"echo"}}
+  creationTimestamp: "2021-07-30T16:11:57Z"
+  generation: 1
+  name: echo-backend
+  namespace: ambassador
+  resourceVersion: "1239310"
+  uid: 3fc67511-6e04-4d56-bde2-5de07fcc9748
+spec:
+  host: echo.mandrakee.xyz
+  prefix: /echo/
+  service: echo
+ 
+
 ~ kg mapping -n ambassador quote-backend -o yaml  
 ...  
-spec:  
-  host: echo.mandrakee.xyz  
-  prefix: /backend/  
-  service: quote  
-~
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"getambassador.io/v2","kind":"Mapping","metadata":{"annotations":{},"name":"echo-backend","namespace":"ambassador"},"spec":{"host":"echo.mandrakee.xyz","prefix":"/echo/","service":"echo"}}
+  creationTimestamp: "2021-07-30T16:11:57Z"
+  generation: 1
+  name: echo-backend
+  namespace: ambassador
+  resourceVersion: "1239310"
+  uid: 3fc67511-6e04-4d56-bde2-5de07fcc9748
+spec:
+  host: echo.mandrakee.xyz
+  prefix: /echo/
+  service: echo
+root@ubuntu-s-1vcpu-2gb-fra1-01:~/setup/AES# kg mapping -n ambassador quote-backend -o yaml
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"getambassador.io/v2","kind":"Mapping","metadata":{"annotations":{},"name":"quote-backend","namespace":"ambassador"},"spec":{"host":"test.mandrakee.xyz","prefix":"/backend/","service":"quote"}}
+  creationTimestamp: "2021-07-30T16:11:56Z"
+  generation: 1
+  name: quote-backend
+  namespace: ambassador
+  resourceVersion: "1239306"
+  uid: 6f7e1766-5554-435a-8335-bc7371b89ada
+spec:
+  host: test.mandrakee.xyz
+  prefix: /backend/
+  service: quote
+ 
  ```
 
 Now let us test the connectivity.

--- a/README.md
+++ b/README.md
@@ -406,6 +406,22 @@ server: envoy{
 }%
 ```
 
+### :clapper: Funny Summary
+```mermaid
+sequenceDiagram
+DO->> Lets-encrypt: Hello Lets-encrypt, Please sign my hosts?
+Lets-encrypt-->>DO: Sure IT takes for a while ~30s?
+DO->>Ambassador: Can you create a gateway for my echo and test service?
+Ambassador-->> DO: Sure, But Where is your service and Certs!
+Note right of Ambassador: Ambassador will mapping services <br/>by using Mapping.yml <br/>that's it<br/>
+
+DO-->> Ambassador: Let me check...
+DO->> Lets-encrypt: Yes... Lets-encrypt,what about our certs?
+Lets-encrypt-->>DO: it's done!
+DO->> Ambassador: you can use our Service.yml with signed TLS.
+Ambassador-->>DO:Thank you... Done! Can you check them all please!
+Note right of DO: DO can use <br/> "kg mapping -A" command<br/> on any terminal bonded to  Kubernetes Cluster for watching summary.<br/>
+```
 
 
 ## Service mesh using Linkerd <a name="LINK"></a>

--- a/README.md
+++ b/README.md
@@ -401,6 +401,11 @@ Ambassador Edge Stack is designed around a [declarative, self-service management
 https://www.getambassador.io/docs/edge-stack/1.13/topics/using/intro-mappings/
 
 This Mapping is managing Edge Stack to route all traffic inbound to the /backend/ path to the quote & also /echo/ to the echo service.
+**Details**
+
+* name:	It's a string identifying the Mapping (e.g. in diagnostics)
+* prefix:	It's the URL prefix identifying your resource.
+* service: It's the name of the service handling the resource; must include the namespace (e.g. myservice.othernamespace) if the service is in a different namespace than Ambassador Edge Stack.
 
 **Mapping.yml**:
 Creating 2 independent mappings - echo services accessible to test.kubenuggets.dev host, and quote service accessible to echo.kubenuggets.dev host.

--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Mapping 2 services with prefix,host,service showing below it is totally easy ple
 **Mapping.yml**:
 Creating 2 independent mappings - echo services accessible to test.kubenuggets.dev host, and quote service accessible to echo.kubenuggets.dev host.
 ```
+~kapp mapping.yml
 ---
 apiVersion: getambassador.io/v2
 kind: Mapping

--- a/README.md
+++ b/README.md
@@ -598,36 +598,70 @@ Now let us test the connectivity.
 
 Checking test service with echo endpoint. Being sure it returns 200 OK.
 ```
-~ curl -Li [http://test.mandrakee.xyz/echo/](http://test.mandrakee.xyz/echo/)     
-HTTP/1.1 301 Moved Permanently  
-location: [https://test.mandrakee.xyz/echo/](https://test.mandrakee.xyz/echo/)  
-date: Sun, 25 Jul 2021 22:12:54 GMT  
-server: envoy  
-content-length: 0HTTP/1.1 200 OK  
-content-type: text/plain  
-date: Sun, 25 Jul 2021 22:12:55 GMT  
-content-length: 366  
-x-envoy-upstream-service-time: 1  
+
+~ curl -Li http://echo.mandrakee.xyz/echo/
+HTTP/1.1 404 Not Found
+date: Sun, 25 Jul 2021 22:13:04 GMT
 server: envoy
+content-length: 0
+~ 
+
+
+~ curl -Li http://test.mandrakee.xyz/echo/   
+HTTP/1.1 301 Moved Permanently
+location: https://test.mandrakee.xyz/echo/
+date: Sun, 25 Jul 2021 22:12:54 GMT
+server: envoy
+content-length: 0
+HTTP/1.1 200 OK
+content-type: text/plain
+date: Sun, 25 Jul 2021 22:12:55 GMT
+content-length: 366
+x-envoy-upstream-service-time: 1
+server: envoy
+Request served by echo-deployment-869b7bf9c7-m2qgs
+HTTP/1.1 GET /
+Host: test.mandrakee.xyz
+User-Agent: curl/7.64.1
+Accept: */*
+X-Forwarded-For: xxx
+X-Forwarded-Proto: https
+X-Request-Id: 32343d7b-1737-4506-b29c-0622d9554cb4
+X-Envoy-Original-Path: /echo/
+X-Envoy-External-Address: xxx
+X-Envoy-Expected-Rq-Timeout-Ms: 3000
+Content-Length: 0
+
+
+
 ```
 Checking echo service with backend endpoint. Being sure it returns 200 OK.
 
 ```
-~ curl -Li [http://echo.mandrakee.xyz/backend/](http://echo.mandrakee.xyz/backend/)  
-HTTP/1.1 301 Moved Permanently  
-location: [https://echo.mandrakee.xyz/backend/](https://echo.mandrakee.xyz/backend/)  
-date: Sun, 25 Jul 2021 22:12:25 GMT  
-server: envoy  
-content-length: 0HTTP/1.1 200 OK  
-content-type: application/json  
-date: Sun, 25 Jul 2021 22:12:25 GMT  
-content-length: 156  
-x-envoy-upstream-service-time: 0  
-server: envoy{  
-    "server": "gargantuan-kiwi-irbqzsp6",  
-    "quote": "A principal idea is omnipresent, much like candy.",  
-    "time": "2021-07-25T22:12:25.764754935Z"  
-}%
+~ curl -Li http://test.mandrakee.xyz/backend/ 
+HTTP/1.1 404 Not Found
+date: Sun, 25 Jul 2021 22:12:13 GMT
+server: envoy
+content-length: 0
+
+
+~ curl -Li http://echo.mandrakee.xyz/backend/
+HTTP/1.1 301 Moved Permanently
+location: https://echo.mandrakee.xyz/backend/
+date: Sun, 25 Jul 2021 22:12:25 GMT
+server: envoy
+content-length: 0
+HTTP/1.1 200 OK
+content-type: application/json
+date: Sun, 25 Jul 2021 22:12:25 GMT
+content-length: 156
+x-envoy-upstream-service-time: 0
+server: envoy
+{
+    "server": "gargantuan-kiwi-irbqzsp6",
+    "quote": "A principal idea is omnipresent, much like candy.",
+    "time": "2021-07-25T22:12:25.764754935Z"
+}
 ```
 
 ## Service mesh using Linkerd <a name="LINK"></a>

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Now connect loki data source to grafana. Go the grafana web console, and add set
 
 Now you can access logs from explore tab of grafana. Make sure to select loki as the data source. Use help button for log search cheat sheet.
 
-## Ingress using Ambassador <a name="AMBA"></a>
+## Ingress using Ambassador
 
 ### Options for LB and Ingress
 
@@ -194,26 +194,23 @@ Let us say you are exposing REST or GRPC API's for different tasks (reading acco
 As there are many vendors, kubernetes API has an ingress spec. The idea is that developers should be able to use the ingress api, and it should work with any vendor. That works well, but has limited capability in the current version. The new version of ingress is called Gateway API and is currently in alpha. The idea is same - users should be able to provide a rich set of ingress configuration using gateway API syntax. As long as the vendor supports gateway API, users will be able to manage the ingress in a vendor-agnostic configuration.
 
 
-We will use Ambassador/Edge Stack for this tutorial. You can pick ANY ingress/api-gateway as long as it is well-supported, has a vibrant community. We may more options for ingress in future.
+We will use Ambassador Edge Stack for this tutorial. You can pick ANY ingress/api-gateway as long as it is well-supported, has a vibrant community. We may more options for ingress in future.
 
   
 
-### Ambassador/Edge Stack
+### Ambassador Edge Stack
+Ambassador Edge Stack is a specialized [control plane for Envoy Proxy](https://blog.getambassador.io/the-importance-of-control-planes-with-service-meshes-and-front-proxies-665f90c80b3d). In this architecture, Ambassador Edge Stack translates configuration (in the form of Kubernetes Custom Resources) to Envoy configuration. All actual traffic is directly handled by the high-performance [Envoy Proxy](https://www.envoyproxy.io/).
 
-We can create our starter kit environment with 5 easy steps and for these steps will need 5 yml files. Our sample solution has 2 services signed Acme certifications with Ambassador GateWay. 
+#### Details
 
-```mermaid
-graph LR
-A[Create 2 YMLs : Deploy & Service] -- For Deployment --> B((Deployment.yml))
-A  -- For Service --> C(Service.yml)
-B --> D{Mapping}
-C --> D
-D -->E(Curling)
-```
-> #### <i class="fa fa-gear fa-spin fa-2x" style="color: firebrick"></i> Configuration :capital_abcd:
-> Configuration will help Deployment yaml which can be launched 2 sample services (quote and echo)  from the **Deployment -> Service** . 
+1.  The service owner defines configuration in Kubernetes manifests.
+2.  When the manifest is applied to the cluster, the Kubernetes API notifies Ambassador Edge Stack of the change.
+3.  Ambassador Edge Stack parses the change and transforms the configuration into a semantic intermediate representation. Envoy configuration is generated from this IR.
+4.  The new configuration is passed to Envoy via the gRPC-based Aggregated Discovery Service (ADS) API.
+5.  Traffic flows through the reconfigured Envoy, without dropping any connections.
 
  #### :arrow_down_small: Install Ambassador
+ We'll start by installing Ambassador Edge Stack into your cluster. Helm helps you manage required packages.
  Installing  Ambassador using helm. - stable 1.13 version
  Instructions - https://www.getambassador.io/docs/edge-stack/1.13/tutorials/getting-started/
 
@@ -405,24 +402,6 @@ server: envoy{
     "time": "2021-07-25T22:12:25.764754935Z"  
 }%
 ```
-
-### :clapper: Funny Summary
-```mermaid
-sequenceDiagram
-DO->> Lets-encrypt: Hello Lets-encrypt, Please sign my hosts?
-Lets-encrypt-->>DO: Sure IT takes for a while ~30s?
-DO->>Ambassador: Can you create a gateway for my echo and test service?
-Ambassador-->> DO: Sure, But Where is your service and Certs!
-Note right of Ambassador: Ambassador will mapping services <br/>by using Mapping.yml <br/>that's it<br/>
-
-DO-->> Ambassador: Let me check...
-DO->> Lets-encrypt: Yes... Lets-encrypt,what about our certs?
-Lets-encrypt-->>DO: it's done!
-DO->> Ambassador: you can use our Service.yml with signed TLS.
-Ambassador-->>DO:Thank you... Done! Can you check them all please!
-Note right of DO: DO can use <br/> "kg mapping -A" command<br/> on any terminal bonded to  Kubernetes Cluster for watching summary.<br/>
-```
-
 
 ## Service mesh using Linkerd <a name="LINK"></a>
 TBD

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ Because of using L4 LB , we have to enable proxy protocol through an annotation.
 
 ###  :book: Summary
 
->Checking  configurations 2 hosts with TLS termination and ACME protocol.
+>Checking configurations 2 hosts with TLS termination and ACME protocol in this setup. test.kubenuggets.dev and echo.kubenuggets.dev are binding directly ambassador gateway. Because of that, having been a map between hosts and ambassador gateways helps clients for using ambassador tls and gateway technologies. When you ping test.kubenuggets.dev, or echo.kubenuggets.dev on the terminal, you can see that it is routing ambassador endpoints. After that, the ambassador is using the mapping feature for mapping target endpoints. 
 
 ```
 ~ kg host -A                                                              

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Ambassador Edge Stack is designed around a [declarative, self-service management
 > More info : :pushpin:
 https://www.getambassador.io/docs/edge-stack/1.13/topics/using/intro-mappings/
 
-Mapping 2 services with prefix,host,service showing below it is totally easy please check above link and understand it's means.
+This Mapping is managing Edge Stack to route all traffic inbound to the /backend/ path to the quote & also /echo/ to the echo service.
 
 **Mapping.yml**:
 Creating 2 independent mappings - echo services accessible to test.kubenuggets.dev host, and quote service accessible to echo.kubenuggets.dev host.

--- a/README.md
+++ b/README.md
@@ -498,14 +498,20 @@ spec:
   ```
 
 ### Enabling Proxy Protocol
-Because of using L4 LB , we will not see the client IP at the destination. We will see the LB IP. So we need to enable proxy protocol through an annotation on the LB. After running this command, the load balancers that expose your LB with the PROXY protocol feature enabled. [FIX IT]
+There are lot of configuration options available to you when running Ambassador Edge Stack but we will focus on automatic certificate management in the Ambassador Edge Stack in this part. After deploying the Service above  and manually enabling the proxy protocol you have to need to deploy the following Ambassador Module to manage Ambassador Edge Stack to utilize the proxy protocol and then restart Ambassador Edge Stack for the configuration to take effect.
 
-[ADD A LINK TO DIGITALOCEAN DOKS PROXY PROTOCOL HOW TO]
+[For More details about how to use proxy for Ambassador](https://www.getambassador.io/docs/edge-stack/1.13/topics/running/ambassador-with-aws/). You can create a proxy in Ambassador by using below code.Ambassador Edge Stack will now expect traffic from the load balancer to be wrapped with the proxy protocol so it can read the client IP address.
 
 ```
-~ kgsvcn ambassador ambassador -o yaml | grep proxy        
-    service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"  
-~
+ 
+apiVersion: getambassador.io/v2
+kind: Module
+metadata:
+  name: ambassador
+  namespace: ambassador
+spec:
+  config:
+    use_proxy_proto: true
 ```
 
 ### Verify the Configuration
@@ -515,7 +521,6 @@ Because of using L4 LB , we will not see the client IP at the destination. We wi
 ```
 ~ kg host -A                                                              
 NAMESPACE    NAME                                HOSTNAME                            STATE   PHASE COMPLETED   PHASE PENDING   AGE  
-ambassador   charming-galileo-913.edgestack.me   charming-galileo-913.edgestack.me   Ready                                     13h  
 default      example-host                        test.mandrakee.xyz                  Ready                                     18h  
 default      example2-host                       echo.mandrakee.xyz                  Ready                                     9m19s
 ```

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Now connect loki data source to grafana. Go the grafana web console, and add set
 
 Now you can access logs from explore tab of grafana. Make sure to select loki as the data source. Use help button for log search cheat sheet.
 
-## Ingress using Ambassador
+## Ingress using Ambassador <a name="AMBA"></a>
 
 ### Options for LB and Ingress
 
@@ -303,9 +303,9 @@ kind: Host
 metadata:
   name: example2-host
 spec:
-  hostname: echo.kubenuggets.dev
+  hostname: echo.mandrakee.xyz
   acmeProvider:
-    email: bikram.gupta@gmail.com
+    email: test@gmail.com
   tlsSecret:
     name: tls2-cert
   requestPolicy:
@@ -320,10 +320,10 @@ It takes ~30 seconds to get the signed certificate for the hosts. At this point,
 
 ### Configure your domain mapping to point the domains to the cluster LB
 
-Here  hosting 2 hosts (echo.kubenuggets.dev, test.kubenuggets.dev) on the same cluster.
+Here  hosting 2 hosts (echo.mandrakee.xyz, test.mandrakee.xyz) on the same cluster.
 
 ```
-~ doctl compute domain records list kubenuggets.dev  
+~ doctl compute domain records list mandrakee.xyz  
 ID           Type    Name    Data                    Priority    Port    TTL     Weight  
 158200732    SOA     @       1800                    0           0       1800    0  
 158200733    NS      @       ns1.digitalocean.com    0           0       1800    0  
@@ -467,7 +467,11 @@ This Mapping is managing Edge Stack to route all traffic inbound to the /backend
 * service: It's the name of the service handling the resource; must include the namespace (e.g. myservice.othernamespace) if the service is in a different namespace than Ambassador Edge Stack.
 
 **Mapping.yml**:
-Creating 2 independent mappings - echo services accessible to test.kubenuggets.dev host, and quote service accessible to echo.kubenuggets.dev host.
+Creating 2 independent mappings 
+
+- echo services accessible to test.mandrakee.xyz AND and quote service accessible to echo.mandrakee.xyz
+  
+
 ```
 ~kapp mapping.yml
 ---
@@ -506,14 +510,14 @@ Because of using L4 LB , we will not see the client IP at the destination. We wi
 
 ### Verify the Configuration
 
->Checking configurations 2 hosts with TLS termination and ACME protocol in this setup. test.kubenuggets.dev and echo.kubenuggets.dev are binding directly ambassador gateway. Because of that, having been a map between hosts and ambassador gateways helps clients for using ambassador tls and gateway technologies. When you ping test.kubenuggets.dev, or echo.kubenuggets.dev on the terminal, you can see that it is routing ambassador endpoints. After that, the ambassador is using the mapping feature for mapping target endpoints. 
+>Checking configurations 2 hosts with TLS termination and ACME protocol in this setup. test.mandrakee.xyz and echo.mandrakee.xyz are binding directly ambassador gateway. Because of that, having been a map between hosts and ambassador gateways helps clients for using ambassador tls and gateway technologies. When you ping test.mandrakee.xyz, or echo.mandrakee.xyz on the terminal, you can see that it is routing ambassador endpoints. After that, the ambassador is using the mapping feature for mapping target endpoints. 
 
 ```
 ~ kg host -A                                                              
 NAMESPACE    NAME                                HOSTNAME                            STATE   PHASE COMPLETED   PHASE PENDING   AGE  
 ambassador   charming-galileo-913.edgestack.me   charming-galileo-913.edgestack.me   Ready                                     13h  
-default      example-host                        test.kubenuggets.dev                Ready                                     18h  
-default      example2-host                       echo.kubenuggets.dev                Ready                                     9m19s
+default      example-host                        test.mandrakee.xyz                  Ready                                     18h  
+default      example2-host                       echo.mandrakee.xyz                  Ready                                     9m19s
 ```
 > Checking  2 independent mappings. Please be sure mapping is correct such as source host etc.
 
@@ -524,19 +528,20 @@ ambassador   ambassador-devportal                                 /documentation
 ambassador   ambassador-devportal-api                             /openapi/                                   127.0.0.1:8500             
 ambassador   ambassador-devportal-assets                          /documentation/(assets|styles)/(.*)(.css)   127.0.0.1:8500             
 ambassador   ambassador-devportal-demo                            /docs/                                      127.0.0.1:8500             
-ambassador   quote-backend                 echo.kubenuggets.dev   /backend/                                   quote                      
-default      echo-backend                  test.kubenuggets.dev   /echo/                                      echo-service               
+ambassador   quote-backend                 echo.mandrakee.xyz     /backend/                                   quote                      
+default      echo-backend                  test.mandrakee.xyz     /echo/                                      echo-service      
+
 ~ kg mapping -n ambassador echo-backend -o yaml  
 ...  
 spec:  
-  host: test.kubenuggets.dev  
+  host: test.mandrakee.xyz  
   prefix: /echo/  
   service: echo-service  
 ~   
 ~ kg mapping -n ambassador quote-backend -o yaml  
 ...  
 spec:  
-  host: echo.kubenuggets.dev  
+  host: echo.mandrakee.xyz  
   prefix: /backend/  
   service: quote  
 ~
@@ -546,9 +551,9 @@ Now let us test the connectivity.
 
 Checking test service with echo endpoint. Being sure it returns 200 OK.
 ```
-~ curl -Li [http://test.kubenuggets.dev/echo/](http://test.kubenuggets.dev/echo/)     
+~ curl -Li [http://test.mandrakee.xyz/echo/](http://test.mandrakee.xyz/echo/)     
 HTTP/1.1 301 Moved Permanently  
-location: [https://test.kubenuggets.dev/echo/](https://test.kubenuggets.dev/echo/)  
+location: [https://test.mandrakee.xyz/echo/](https://test.mandrakee.xyz/echo/)  
 date: Sun, 25 Jul 2021 22:12:54 GMT  
 server: envoy  
 content-length: 0HTTP/1.1 200 OK  
@@ -561,9 +566,9 @@ server: envoy
 Checking echo service with backend endpoint. Being sure it returns 200 OK.
 
 ```
-~ curl -Li [http://echo.kubenuggets.dev/backend/](http://echo.kubenuggets.dev/backend/)  
+~ curl -Li [http://echo.mandrakee.xyz/backend/](http://echo.mandrakee.xyz/backend/)  
 HTTP/1.1 301 Moved Permanently  
-location: [https://echo.kubenuggets.dev/backend/](https://echo.kubenuggets.dev/backend/)  
+location: [https://echo.mandrakee.xyz/backend/](https://echo.mandrakee.xyz/backend/)  
 date: Sun, 25 Jul 2021 22:12:25 GMT  
 server: envoy  
 content-length: 0HTTP/1.1 200 OK  

--- a/README.md
+++ b/README.md
@@ -209,6 +209,9 @@ Ambassador Edge Stack is a specialized [control plane for Envoy Proxy](https://b
 4.  The new configuration is passed to Envoy via the gRPC-based Aggregated Discovery Service (ADS) API.
 5.  Traffic flows through the reconfigured Envoy, without dropping any connections.
 
+More Details and extended explanation please visit: [Yhe Ambassador Edge Stack Architecture](https://www.getambassador.io/docs/edge-stack/2.0/topics/concepts/architecture/) 
+
+
  #### :arrow_down_small: Install Ambassador
  We'll start by installing Ambassador Edge Stack into your cluster. Helm helps you manage required packages.
  Installing  Ambassador using helm. - stable 1.13 version


### PR DESCRIPTION
- update for Getting traffic in using TLS and LetsEncrypt certificates
- update cer manager side for edge stack
- How to use Ambassador to host multiple TLS-enabled hosts on the same cluster
- How to use Ambassador to host multiple TLS-enabled hosts on the same cluster-2
- make ambassador edge stak with details and simplified
- make ambassador edge stak with details and simplified
- make ambassador edge stak with details and simplified
- added more details about service,deploy etc. yml
- added more details about service,deploy etc. yml 2
- added more details about service,deploy etc. yml 2
- enrichment content for edge stack,mapping etc.
- enrichment content for edge stack,mapping etc.
- enrichment mapping content
- enrichment mapping content
- enrichment mapping content
