### PR TITLE
Helm chart version lock for Ambassador, Prometheus, Loki and Velero

### DIFF
--- a/3-setup-ingress-ambassador/README.md
+++ b/3-setup-ingress-ambassador/README.md
@@ -62,30 +62,43 @@ In this section you will deploy the `Ambassador Edge Stack` into the `DOKS` clus
 
 Steps to follow:
 
-1. Add the Helm repo:
+1. Add the Helm repo and list the available charts:
 
     ```shell
     helm repo add datawire https://www.getambassador.io
-    helm repo update
-    ```
-2. List the available versions (pick the `6.7.13` version of the `Chart` which maps to the `1.13.0` release of `AES`):
 
-    ```shell
     helm search repo datawire
     ```
-   
-   The output looks similar to the following:
-   ```
-   NAME                            CHART VERSION   APP VERSION     DESCRIPTION                                       
-   datawire/ambassador             6.7.13          1.13.10         A Helm chart for Datawire Ambassador              
-   datawire/ambassador-operator    0.3.0           v1.3.0          A Helm chart for Kubernetes                       
-   datawire/telepresence           2.4.0           2.4.0           A chart for deploying the server-side component...
-   ```
-3. Create a dedicated `ambassador` namespace and finish the installation with:
+
+    The output looks similar to the following:
+    ```
+    NAME                            CHART VERSION   APP VERSION     DESCRIPTION                                       
+    datawire/ambassador             6.7.13          1.13.10         A Helm chart for Datawire Ambassador              
+    datawire/ambassador-operator    0.3.0           v1.3.0          A Helm chart for Kubernetes                       
+    datawire/telepresence           2.4.0           2.4.0           A chart for deploying the server-side component...
+    ```
+
+    **Note:**
+
+    The chart of interes is `datawire/ambassador`, which will install `Ambassador Edge Stack` on the cluster. Please visit the [ambassador-chart](https://github.com/datawire/ambassador-chart) page for more details about this chart.
+2. Fetch and inspect the values file to see what options are available:
 
     ```shell
-    helm install ambassador datawire/ambassador --version 6.7.13 --namespace ambassador --create-namespace
+    helm show values datawire/ambassador --version 6.7.13 > ambassador-values.yaml
     ```
+
+    **Hint:**
+
+    It's good practice in general to fetch the values file and inspect it to see what options are available. This way, you can keep for example only the features that you need for your project and disable others to save on resources.
+3. Finish the installation (a dedicated `ambassador` namespace will be created as well):
+
+    ```shell
+    helm install datawire/ambassador --version 6.7.13 --namespace ambassador --create-namespace ambassador
+    ```
+
+    **Note:**
+
+    A `specific` version for the `Helm` chart is used. In this case `6.7.13` was picked, which maps to the `1.13.10` release of `AES` (see the output from `Step 1.`). It's good practice in general to lock on a specific version or range (e.g. `^6.7.13`). This helps to avoid future issues caused by breaking changes introduced in major version releases. On the other hand, it doesn't mean that a future major version ugrade is not an option. You need to make sure that the new version is tested first. Having a good strategy in place for backups and snapshots becomes handy here (covered in more detail in [Section 6 - Backup Using Velero](../6-setup-velero)).
 
 
 ### Defining the Domain and Hosts

--- a/5-setup-loki-stack/README.md
+++ b/5-setup-loki-stack/README.md
@@ -32,40 +32,59 @@ This is how the main setup looks like after completing this tutorial:
 
 ### Installing LOKI
 
-We need [Loki](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack) for logs. `Loki` runs on the cluster itself as a `StatefulSet`. Logs are aggregated and compressed by `Loki`, then sent to the configured storage. Then, you can connect `Loki` data source to `Grafana` and view the logs.
+We need [Loki](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack) for logs. `Loki` runs on the cluster itself as a `StatefulSet`. Logs are `aggregated` and `compressed` by `Loki`, then sent to the configured `storage`. Then, you can connect `Loki` data source to `Grafana` and view the logs.
 
 Steps to follow:
 
-1. Add the required `Helm` repository first:
+1. Add the `Helm` repo and list the available charts:
 
     ```shell
     helm repo add grafana https://grafana.github.io/helm-charts
+
     helm search repo grafana
     ```
 
-    We are interested in the `grafana/loki-stack`, which will install standalone `Loki` on the cluster.
+    The output looks similar to the following:
 
-2. Fetch the values file:
+    ```
+    NAME                                            CHART VERSION   APP VERSION     DESCRIPTION                                       
+    grafana/grafana                                 6.16.2          8.1.2           The leading tool for querying and visualizing t...
+    grafana/enterprise-metrics                      1.5.0           v1.5.0          Grafana Enterprise Metrics                        
+    grafana/fluent-bit                              2.3.0           v2.1.0          Uses fluent-bit Loki go plugin for gathering lo...
+    grafana/loki                                    2.4.1           v2.1.0          Loki: like Prometheus, but for logs.
+    ...
+    ```
+
+    **Note:**
+
+    The chart of interes is `grafana/loki-stack`, which will install standalone `Loki` on the cluster. Please visit the [loki-stack](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack) page for more details about this chart.
+
+2. Fetch and inspect the values file:
 
     ```shell
-    helm show values grafana/loki-stack > loki-values.yaml
+    helm show values grafana/loki-stack --version 2.4.1 > loki-values.yaml
     ```
 
     **Hint:**
 
     It's good practice in general to fetch the values file and inspect it to see what options are available. This way, you can keep for example only the features that you need for your project and disable others to save on resource usage.
 
-3. Install the stack. You will disable `Prometheus` and `Grafana` installation, because [Section 4 - Set up Prometheus Stack](../4-setup-prometheus-stack) took care of it already. `Promtail` is needed so it will be enabled. The following command will take care of everything for you:
+3. Install the stack. The following command will take care of everything for you:
 
     ```shell
-    helm install loki \
+    helm install loki grafana/loki-stack --version 2.4.1 \
       --namespace=monitoring \
       --create-namespace \
       --set grafana.enabled=false \
       --set prometheus.enabled=false \
       --set promtail.enabled=true \
-      grafana/loki-stack
     ``` 
+
+    **Notes:**
+
+    * A `specific` version for the `Helm` chart is used. In this case `2.4.1` was picked, which maps to the `2.1.0` release of `Loki` (see the output from `Step 1.`). It's good practice in general to lock on a specific version or range (e.g. `^2.4.1`). This helps to avoid future issues caused by breaking changes introduced in major version releases. On the other hand, it doesn't mean that a future major version ugrade is not an option. You need to make sure that the new version is tested first. Having a good strategy in place for backups and snapshots becomes handy here (covered in more detail in [Section 6 - Backup Using Velero](../6-setup-velero)).
+    * `Promtail` is needed so it will be enabled (explained in [Promtail](#promtail) section).
+    * `Prometheus` and `Grafana` installation is disabled because [Section 4 - Set up Prometheus Stack](../4-setup-prometheus-stack) took care of it already.
 
 In the next part you will configure `Grafana` to use the `Loki` datasource so that you can query for logs.
 

--- a/6-setup-velero/README.md
+++ b/6-setup-velero/README.md
@@ -76,24 +76,44 @@ In the next part, you will deploy `Velero` and all the required components so th
 
 Steps to follow:
 
-1. Add the `Helm` repository:
+1. Add the `Helm` repo and list the available charts:
 
     ```
     helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts
+
+    helm search repo vmware-tanzu
     ```
 
-2. A cloud credentials file is needed in order for `Velero` to access `DO Spaces`. Create a file named `secrets.txt` under the current working directory with the following content (make sure to replace the `<>` placeholders accordingly):
+    The output looks similar to the following:
+
+    ```
+    NAME                    CHART VERSION   APP VERSION     DESCRIPTION            
+    vmware-tanzu/velero     2.23.6          1.6.3           A Helm chart for velero
+    ```
+
+    **Note:**
+
+    The chart of interes is `vmware-tanzu/velero`, which will install `Velero` on the cluster. Please visit the [velero-chart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero) page for more details about this chart.
+2. Fetch and inspect the values file to see what options are available:
+
+    ```shell
+    helm show values vmware-tanzu/velero --version 2.23.6 > velero-values.yaml
+    ```
+
+    **Hint:**
+
+    It's good practice in general to fetch the values file and inspect it to see what options are available. This way, you can keep for example only the features that you need for your project and disable others to save on resources.
+3. A cloud credentials file is needed in order for `Velero` to access `DO Spaces`. Create a file named `secrets.txt` under the current working directory with the following content (make sure to replace the `<>` placeholders accordingly):
 
     ```
     [default]
     aws_access_key_id=<DO_SPACES_ACCESS_KEY_ID>
     aws_secret_access_key=<DO_SPACES_SECRET_ACCESS_KEY>
     ```
-
-3. Deploy `Velero` using `Helm` (make sure to replace the `<>` placeholders accordingly):
+4. Deploy `Velero` using `Helm` (make sure to replace the `<>` placeholders accordingly):
 
     ```shell
-    helm install velero vmware-tanzu/velero \
+    helm install velero vmware-tanzu/velero --version 2.23.6 \
     --namespace velero \
     --create-namespace \
     --set credentials.extraEnvVars.digitalocean_token=<DIGITALOCEAN_API_TOKEN>  \
@@ -124,7 +144,11 @@ Steps to follow:
     * `<deployRestic=false>` - whether to deploy the restic daemonset (disabled in this example because it's considered beta).
     * `<DIGITALOCEAN_API_TOKEN>` - your DigitalOcean API Token. Velero needs it in order to authenticate with the DigitalOcean API when manipulating snapshots.
     * `<BUCKET_NAME>` and `<REGION>` - your DigitalOcean Spaces bucket name and region (e.g.: `nyc3`) created in the [Prerequisites](#prerequisites) section.
-4. Check the `Velero` deployment:
+
+    **Note:**
+
+    A `specific` version for the `Helm` chart is used. In this case `2.23.6` was picked, which maps to the `1.6.3` release of `Velero` (see the output from `Step 1.`). It's good practice in general to lock on a specific version or range (e.g. `^2.23.6`). This helps to avoid future issues caused by breaking changes introduced in major version releases. On the other hand, it doesn't mean that a future major version ugrade is not an option. You need to make sure that the new version is tested first. Having a good strategy in place for backups and snapshots becomes handy here (covered in more detail in [Section 6 - Backup Using Velero](../6-setup-velero)).
+5. Check the `Velero` deployment:
 
     ```shell
     helm ls -n velero
@@ -136,8 +160,7 @@ Steps to follow:
     NAME    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
     velero  velero          1               2021-08-25 13:16:24.383446 +0300 EEST   deployed        velero-2.23.6   1.6.3 
     ```
-
-5. Check that `Velero` is up and running:
+6. Check that `Velero` is up and running:
 
     ```shell
     kubectl get deployment velero -n velero


### PR DESCRIPTION
## Overview

Make sure to `lock` on a `specific version` for each `Helm Chart` install step used in the tutorial because:
 - Helm repo update causes `backward compatibility issues`
 - When `restoring` an older snapshot via `Velero` and the fetched `values file` is for a newer version of the Helm Chart things will break